### PR TITLE
SEO discoverability: meta tags and stale domain cleanup

### DIFF
--- a/.github/workflows/sync-schema.yml
+++ b/.github/workflows/sync-schema.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get latest schema release
         id: schema-release
         run: |
-          LATEST_TAG=$(curl -s https://api.github.com/repos/nmr-samples/schema/releases/latest | jq -r .tag_name)
+          LATEST_TAG=$(curl -s https://api.github.com/repos/NMRSamples/schema/releases/latest | jq -r .tag_name)
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "Latest schema version: $LATEST_TAG"
       
@@ -43,7 +43,7 @@ jobs:
           rm -rf src/schemas
           
           # Clone the schema repository
-          git clone https://github.com/nmr-samples/schema.git src/schemas
+          git clone https://github.com/NMRSamples/schema.git src/schemas
           
           # Remove the .git directory (we don't need the schema repo's git history)
           rm -rf src/schemas/.git
@@ -60,7 +60,7 @@ jobs:
           delete-branch: true
           title: "Update schemas to ${{ steps.schema-release.outputs.latest_tag }}"
           body: |
-            Automated schema update from [nmr-sample-schema](https://github.com/nmr-samples/schema).
+            Automated schema update from [nmr-sample-schema](https://github.com/NMRSamples/schema).
             
             New version: ${{ steps.schema-release.outputs.latest_tag }}
             Previous version: ${{ steps.current-version.outputs.current_version }}
@@ -69,4 +69,4 @@ jobs:
             
             Please review the changes and test compatibility before merging.
             
-            Schema release: https://github.com/nmr-samples/schema/releases/tag/${{ steps.schema-release.outputs.latest_tag }}
+            Schema release: https://github.com/NMRSamples/schema/releases/tag/${{ steps.schema-release.outputs.latest_tag }}

--- a/src/getting-started.html
+++ b/src/getting-started.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NMR Sample Manager (online)</title>
+    <meta name="description" content="How to get started with the browser-based NMR Sample Manager: online and offline access, setting up directories, and creating, editing, and ejecting sample annotations.">
+    <link rel="canonical" href="https://nmrsamples.github.io/online/getting-started.html">
     <link rel="stylesheet" href="css/docs.css">
 </head>
 
@@ -15,10 +17,10 @@
             <nav class="nav">
                 <a href="index.html" class="nav-link">Web App</a>
                 <a href="getting-started.html" class="nav-link active">Getting started</a>
-                <a href="https://nmr-samples.github.io/topspin" class="nav-link">TopSpin App</a>
-                <a href="https://nmr-samples.github.io/" class="nav-link">Ecosystem</a>
+                <a href="https://nmrsamples.github.io/topspin" class="nav-link">TopSpin App</a>
+                <a href="https://nmrsamples.github.io/" class="nav-link">Ecosystem</a>
                 <a href="https://waudbylab.org/" class="nav-link">Waudby Lab</a>
-                <a href="https://github.com/nmr-samples/online" aria-label="GitHub repository"
+                <a href="https://github.com/NMRSamples/online" aria-label="GitHub repository"
                     title="GitHub repository">
                     <svg height="20" width="20" viewBox="0 0 16 16" fill="currentColor">
                         <path
@@ -88,9 +90,9 @@
         <p>Sample metadata is stored as human-readable JSON files alongside your experiment
             data, with filenames like <code>2025-10-23_143022_lysozyme.json</code>. These
             files can be opened in any text editor and work well with version control. They
-            follow a shared <a href="https://github.com/nmr-samples/schema">open schema</a>,
+            follow a shared <a href="https://github.com/NMRSamples/schema">open schema</a>,
             so they're compatible with the
-            <a href="https://nmr-samples.github.io/topspin/">TopSpin integration</a>,
+            <a href="https://nmrsamples.github.io/topspin/">TopSpin integration</a>,
             <a href="https://github.com/waudbygroup/NMRTools.jl">NMRTools.jl</a>, and other
             tools in the ecosystem.
         </p>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NMR Sample Manager (online)</title>
+    <meta name="description" content="A browser-based NMR sample metadata manager. No installation needed — record sample composition, buffer conditions, and tube details as JSON files alongside your data, right in Chrome or Edge. Companion to the TopSpin plugin.">
+    <link rel="canonical" href="https://nmrsamples.github.io/online/">
     <link rel="stylesheet" href="css/styles.css">
     <!-- Bootstrap and React JSON Schema Form - reliable working version -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
@@ -21,10 +23,10 @@
                 <nav class="app-nav">
                     <a href="index.html" class="nav-link active">Web App</a>
                     <a href="getting-started.html" class="nav-link">Getting started</a>
-                    <a href="https://nmr-samples.github.io/topspin" class="nav-link">TopSpin App</a>
-                    <a href="https://nmr-samples.github.io/" class="nav-link">Ecosystem</a>
+                    <a href="https://nmrsamples.github.io/topspin" class="nav-link">TopSpin App</a>
+                    <a href="https://nmrsamples.github.io/" class="nav-link">Ecosystem</a>
                     <a href="https://waudbylab.org/" class="nav-link">Waudby Lab</a>
-                    <a href="https://github.com/nmr-samples/online" class="nav-link" aria-label="GitHub repository"
+                    <a href="https://github.com/NMRSamples/online" class="nav-link" aria-label="GitHub repository"
                         title="GitHub repository">
                         <svg height="20" width="20" viewBox="0 0 16 16" fill="currentColor">
                             <path
@@ -93,10 +95,10 @@
                                 See the <a href="getting-started.html">Getting Started</a> guide for more detail,
                                 including offline use.</p>
 
-                            <p>Sample files use a shared <a href="https://github.com/nmr-samples/schema">open JSON
+                            <p>Sample files use a shared <a href="https://github.com/NMRSamples/schema">open JSON
                                     schema</a>,
                                 and are compatible with
-                                <a href="https://nmr-samples.github.io/topspin/">TopSpin integration</a> and
+                                <a href="https://nmrsamples.github.io/topspin/">TopSpin integration</a> and
                                 <a href="https://github.com/waudbygroup/NMRTools.jl">NMRTools.jl</a>.
                             </p>
                         </div>


### PR DESCRIPTION
## Summary
- Added `<meta name="description">` and `<link rel="canonical">` to `src/index.html` and `src/getting-started.html`, which previously had only a `<title>`.
- Updated leftover `nmr-samples.github.io` / `github.com/nmr-samples` references to `nmrsamples.github.io` / `github.com/NMRSamples` in both files (nav links, GitHub link, schema link) and in `.github/workflows/sync-schema.yml`.
- `README.md` had no references to the old domain/org, so it's unchanged.
- Left `src/schemas/` untouched — it's synced from `NMRSamples/schema` by the `sync-schema` workflow, out of scope per the task.
- `docs/` (generated by `.github/workflows/build.yml` from `src/`) was not hand-edited, per the build process.

## Test plan
- [x] Confirmed `github.com/NMRSamples/NMRSamples.github.io` exists (200) via the GitHub API — the org/repo rename is in place.
- [ ] Could not verify the live `nmrsamples.github.io/online/` site directly (outbound network in this environment blocks that domain) — recommend a quick manual check once `build.yml` regenerates `docs/` from this branch's `src/`.
- [x] Verified no remaining `nmr-samples.github.io` / `github.com/nmr-samples` references outside of `src/schemas/` (out of scope, synced content).


---
_Generated by [Claude Code](https://claude.ai/code/session_018x1LGdzLYmAdJbh1LKsZxG)_